### PR TITLE
(feat) Implement event modal on tooltip touch

### DIFF
--- a/app/components/Map.js
+++ b/app/components/Map.js
@@ -1,39 +1,60 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import {
   StatusBar,
   StyleSheet,
   Text,
   View,
   Navigator,
-  Dimensions
+  Dimensions,
+  TouchableHighlight
 } from 'react-native';
+
+import {
+  MKColor,
+} from 'react-native-material-kit';
 
 import Spinner from './Spinner.js';
 
 import MapView from 'react-native-maps';
 import NewEventModal from './NewEventModal.js';
+import EventModal from './EventModal';
 import OurDrawer from './OurDrawer.js';
 import _navigate from './navigateConfig.js';
 import NewEventFab from './NewEventFab.js';
 
 export default class Map extends Component {
-  constructor (props) {
+  static propTypes = {
+    user: PropTypes.object.isRequired,
+    mongoLocation: PropTypes.array.isRequired
+  }
+
+  constructor(props) {
     super(props);
     this.state = {
       loading: true,
       markers: null,
-      modalVisible: false,
+      newEventModalVisible: false,
+      eventModalVisible: false,
+      eventModalId: 0
     };
+
+    this.setNewEventPinCoords = this.setNewEventPinCoords.bind(this);
+    this.fetchEvents = this.fetchEvents.bind(this);
+    this.openNewEventModal = this.openNewEventModal.bind(this);
+    this.openEventModal = this.openEventModal.bind(this);
+    this.closeEventModal = this.closeEventModal.bind(this);
   }
 
-  setNewEventPinCoords () {
-    this.setState({x: {
-      latitude: this.props.mongoLocation[1] + 0.0005,
-      longitude: this.props.mongoLocation[0] + 0.0005
-    }});
+  setNewEventPinCoords() {
+    this.setState({
+      x: {
+        latitude: this.props.mongoLocation[1] + 0.0005,
+        longitude: this.props.mongoLocation[0] + 0.0005
+      }
+    });
   }
 
-  fetchEvents () {
+  fetchEvents() {
     fetch('http://localhost:3000/api/events/bundle', {
       method: 'POST',
       headers: {
@@ -48,24 +69,64 @@ export default class Map extends Component {
       return data.json();
     })
     .then(data => {
-      console.log('inside fetchEvents', data);
-      this.setState({markers: data, loading: false});
+      this.setState({
+        markers: data,
+        loading: false
+      });
     })
     .catch((err) => {
       console.log(err);
     });
   }
-  componentWillMount () {
+
+  componentWillMount() {
     this.setNewEventPinCoords();
     this.fetchEvents();
   }
-  openModal () {
-    this.setState({modalVisible: true});
+
+  openNewEventModal() {
+    this.setState({
+      newEventModalVisible: true
+    });
   }
-  render () {
-    if(this.state.loading){
+
+  openEventModal(id) {
+    this.setState({
+      eventModalVisible: true,
+      eventModalId: id
+    });
+  }
+
+  closeEventModal() {
+    this.setState({
+      eventModalVisible: false
+    });
+  }
+
+  getEventModal() {
+    if (this.state.eventModalVisible) {
       return (
-        <OurDrawer user={this.props.user} topBarFilterVisible={true} topBarName={'Map'} _navigate={ _navigate.bind(this)}>
+        <EventModal
+          key={this.state.eventModalId}
+          close={this.closeEventModal}
+          user={this.props.user}
+          visibility={this.state.eventModalVisible}
+          event={this.state.eventModalId}
+        />
+      );
+    }
+
+    return null;
+  }
+
+  render () {
+    if (this.state.loading) {
+      return (
+        <OurDrawer user={this.props.user}
+          topBarFilterVisible={true}
+          topBarName={'Map'}
+          _navigate={_navigate.bind(this)}
+        >
           <View style={styles.spinner}>
             <Spinner />
           </View>
@@ -74,7 +135,12 @@ export default class Map extends Component {
     }
     else {
       return (
-        <OurDrawer user={this.props.user} topBarFilterVisible={true} topBarName={'Map'} _navigate={ _navigate.bind(this)}>
+        <OurDrawer
+          user={this.props.user}
+          topBarFilterVisible={true}
+          topBarName={'Map'}
+          _navigate={_navigate.bind(this)}
+        >
           <View>
             <MapView
               showsUserLocation={true}
@@ -85,29 +151,50 @@ export default class Map extends Component {
                 latitudeDelta: .04,
                 longitudeDelta: .02
             }}>
-            <MapView.Marker draggable
+            <MapView.Marker
+              draggable
               coordinate={this.state.x}
               pinColor='yellow'
               title='The location of your next event!'
               onDragEnd={(e) => this.setState({ x: e.nativeEvent.coordinate })}
             />
-            {this.state.markers.map(marker => {
-              var tempLoc = {
-                latitude: marker.location[1],
-                longitude: marker.location[0]
-              }
-              return (
-                <MapView.Marker
-                  key={marker._id}
-                  coordinate={tempLoc}
-                  title={marker.name}
-                  pinColor='blue'
-                />
-              );
-            })}
+
+            {
+              this.state.markers.map(marker => {
+                var tempLoc = {
+                  latitude: marker.location[1],
+                  longitude: marker.location[0]
+                }
+                return (
+                  <MapView.Marker
+                    key={marker._id}
+                    coordinate={tempLoc}
+                    pinColor={MKColor.Indigo}
+                  >
+                    <MapView.Callout width={40} height={40} >
+                      <TouchableHighlight
+                        underlayColor="transparent"
+                        onPress={this.openEventModal.bind(this, marker._id)}
+                      >
+                        <Text>{marker.name}</Text>
+                      </TouchableHighlight>
+                    </MapView.Callout>
+                  </MapView.Marker>
+                );
+              })
+            }
             </MapView>
-            <NewEventFab onPress={this.openModal.bind(this)}/>
-            <NewEventModal resetPin={this.setNewEventPinCoords.bind(this)} fetchNewEvents={this.fetchEvents.bind(this)} userId={this.props.user._id} eventCoords={this.state.x} modalVisibility={this.state.modalVisible}/>
+            <NewEventFab onPress={this.openNewEventModal} />
+            <NewEventModal
+              resetPin={this.setNewEventPinCoords}
+              fetchNewEvents={this.fetchEvents}
+              userId={this.props.user._id}
+              eventCoords={this.state.x}
+              modalVisibility={this.state.newEventModalVisible}
+            />
+            {
+              this.getEventModal()
+            }
           </View>
         </OurDrawer>
       );


### PR DESCRIPTION
Formerly, on the home page, while tapping each event pin would bring up a tooltip with that particular event's title, there was no way to get more details about that event. With these changes, clicking on the tooltip will slide open a details view for that particular event (the same one that is displayed when clicking on an event from the feed view).

Also, the default pin colors now match the indigo color of the new event button. 💃 :godmode:💃 